### PR TITLE
Add DisplayCrown configuration option

### DIFF
--- a/HealthNotes.json
+++ b/HealthNotes.json
@@ -2,6 +2,7 @@
     "/*Language(show different language monster name)*/": "us=english,jp=japanese,cn=chinese",
     "Language": "us",
     "DisplayCapture": true,
+    "DisplayCrown": true,
     "Capture": "<STYL MOJI_RED_DEFAULT>Meowster! the monstername is now able to be captured!</STYL>",
     "Bigcrown": "<STYL MOJI_RED_DEFAULT>monstername size is big crown</STYL>",
     "Bigsilver": "<STYL MOJI_YELLOW_DEFAULT>monstername size is silver crown</STYL>",

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -59,6 +59,10 @@ void handleMonsterCreated(int id, undefined* monster)
 				monsterMessages[monster].push(monsterMessages[monster].front());
 				monsterMessages[monster].pop();
 			}
+
+			if (!isAdd) {
+				monsterMessages[monster].push({ monsters[id].Capture / 100, omessages[0] });
+			}
 		}
 		isInit = false;
 		monsterChecked[monster] = false;

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -14,7 +14,7 @@
 #include "ghidra_export.h"
 #include "util.h"
 
-struct Monster{
+struct Monster {
 	int Id;
 	std::string Name;
 	float Capture;
@@ -30,13 +30,14 @@ static std::mutex lock;
 static struct Monster monsters[102];
 static std::string language;
 static std::string omessages[5];
-static bool isInit=false;
+static bool isInit = false;
 static bool displayCapture = true;
+static bool displayCrown = true;
 
 using namespace loader;
 
 void showMessage(std::string message) {
-	MH::Chat::ShowGameMessage(*(undefined**)MH::Chat::MainPtr, (undefined*) &message[0], -1, -1, 0);
+	MH::Chat::ShowGameMessage(*(undefined**)MH::Chat::MainPtr, (undefined*)&message[0], -1, -1, 0);
 }
 
 void handleMonsterCreated(int id, undefined* monster)
@@ -162,12 +163,13 @@ __declspec(dllexport) extern bool Load()
 	}
 
 	LOG(INFO) << "Health notes loading";
-	
+
 	nlohmann::json ConfigFile = nlohmann::json::object();
 	file >> ConfigFile;
 
 	language = ConfigFile["Language"];
 	displayCapture = ConfigFile["DisplayCapture"];
+	displayCrown = ConfigFile["DisplayCrown"];
 	omessages[0] = ConfigFile["Capture"];
 	omessages[1] = ConfigFile["Bigcrown"];
 	omessages[2] = ConfigFile["Bigsilver"];
@@ -225,19 +227,19 @@ __declspec(dllexport) extern bool Load()
 				for (auto [monster, queue] : monsterMessages) {
 					checkHealth(monster);
 				}
-				if (isInit) {
+				if (isInit && displayCrown) {
 					for (auto [monster, isChecked] : monsterChecked) {
 						if (!isChecked) {
 							checkMonsterSize(monster);
 							monsterChecked[monster] = true;
 						}
-						
+
 					}
-					
+
 				}
 			}
 		}
-	}).detach();
+		}).detach();
 
 	MH_ApplyQueued();
 
@@ -251,6 +253,6 @@ BOOL APIENTRY DllMain(HMODULE hModule,
 {
 	if (ul_reason_for_call == DLL_PROCESS_ATTACH)
 		return Load();
-    return TRUE;
+	return TRUE;
 }
 


### PR DESCRIPTION
Make crown messages optional.

Also fix a bug where capture messages wouldn't show when DisplayCapture is true but there are no ratio messages or there isn't a ratio message whose ratio is below the monster's capture percent.